### PR TITLE
MVP: set up dummyUser page and render a UrlsTable

### DIFF
--- a/js/frontend/src/components/User/UrlsTable.astro
+++ b/js/frontend/src/components/User/UrlsTable.astro
@@ -1,0 +1,79 @@
+---
+import type { UserLink } from "@/lib/types";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+  PaginationLink,
+} from "@/components/ui/pagination";
+import SafeLink from "@/components/shared/SafeLink.astro";
+
+interface UrlsTableProps {
+  userLinks: UserLink[];
+  currentPage: number;
+}
+
+const { userLinks, currentPage } = Astro.props as UrlsTableProps;
+---
+
+<div class="flex flex-col justify-end gap-2">
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead className="w-[100px]">ID</TableHead>
+        <TableHead>MicroUrl</TableHead>
+        <TableHead>Original</TableHead>
+        <TableHead className="text-right">Expiration Date</TableHead>
+        <TableHead className="text-right">Views</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {
+        userLinks.map(({ id, short_url, original_url, expiry_date, views }) => {
+          console.log(short_url);
+
+          return (
+            <TableRow>
+              <TableCell className="font-medium">{id}</TableCell>
+              <TableCell>
+                <SafeLink href={short_url}>{short_url}</SafeLink>
+              </TableCell>
+              <TableCell>
+                <SafeLink href={original_url}>{original_url}</SafeLink>
+              </TableCell>
+              <TableCell className="text-right">{expiry_date}</TableCell>
+              <TableCell className="text-right">{views}</TableCell>
+            </TableRow>
+          );
+        })
+      }
+    </TableBody>
+  </Table>
+  <Pagination className="justify-end">
+    <PaginationContent>
+      <PaginationItem>
+        <PaginationPrevious href="#" />
+      </PaginationItem>
+      <PaginationItem>
+        <PaginationLink href="#">{currentPage}</PaginationLink>
+      </PaginationItem>
+      <PaginationItem>
+        <PaginationEllipsis />
+      </PaginationItem>
+      <PaginationItem>
+        <PaginationNext href="#" />
+      </PaginationItem>
+    </PaginationContent>
+  </Pagination>
+</div>

--- a/js/frontend/src/components/shared/SafeLink.astro
+++ b/js/frontend/src/components/shared/SafeLink.astro
@@ -1,0 +1,17 @@
+---
+interface SafeLinkProps {
+  href: string;
+  children: string;
+}
+
+const { href } = Astro.props as SafeLinkProps;
+---
+
+<a
+  href={href}
+  target="_blank"
+  rel="noopener noreferrer"
+  class="hover:text-blue-700 hover:underline"
+>
+  <slot />
+</a>

--- a/js/frontend/src/components/ui/pagination.tsx
+++ b/js/frontend/src/components/ui/pagination.tsx
@@ -1,0 +1,127 @@
+import * as React from "react"
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button, buttonVariants } from "@/components/ui/button"
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  )
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  )
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/js/frontend/src/components/ui/table.tsx
+++ b/js/frontend/src/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/js/frontend/src/pages/user.astro
+++ b/js/frontend/src/pages/user.astro
@@ -1,0 +1,51 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import type { User } from "@/lib/types";
+import UrlsTable from "@/components/User/UrlsTable.astro";
+const dummyUser: User = {
+  user_id: "123",
+  name: "Peggy Ehler",
+  email: "peggy@ehler.com",
+  created_at: "2021-01-01",
+  updated_at: "2021-01-01",
+};
+---
+
+<Layout content={{ title: "MicroUrl: User" }}>
+  <h2 class="mb-4 text-2xl font-bold">{dummyUser.name}</h2>
+  <UrlsTable
+    currentPage={1}
+    userLinks={[
+      {
+        id: "1",
+        short_url: "https://short.url",
+        original_url: "https://original.url",
+        user_id: "123",
+        expiry_date: "2021-01-01",
+        created_at: "2021-01-01",
+        updated_at: "2021-01-01",
+        views: 100,
+      },
+      {
+        id: "2",
+        short_url: "https://short.url",
+        original_url: "https://original.url",
+        user_id: "123",
+        expiry_date: "2021-01-01",
+        created_at: "2021-01-01",
+        updated_at: "2021-01-01",
+        views: 100,
+      },
+      {
+        id: "3",
+        short_url: "https://short.url",
+        original_url: "https://original.url",
+        user_id: "123",
+        expiry_date: "2021-01-01",
+        created_at: "2021-01-01",
+        updated_at: "2021-01-01",
+        views: 100,
+      },
+    ]}
+  />
+</Layout>


### PR DESCRIPTION
### What
I scaffold out a basic user page w/ introductory pagination. Am adding another ticket to Linear to completely wire this- need to refactor the directory structure to work with server side props & fetch the user URLs

<img width="1913" alt="Screenshot 2025-05-04 at 11 45 14 AM" src="https://github.com/user-attachments/assets/e19c67d6-c9a3-4ce8-90f6-67b4b110753b" />
